### PR TITLE
Add rb_get_partitions and rb_get_consumer_groups scripts

### DIFF
--- a/packaging/rpm/redborder-kafka.spec
+++ b/packaging/rpm/redborder-kafka.spec
@@ -31,6 +31,7 @@ install -D -m 0755 resources/bin/rb_delete_topics.sh %{buildroot}/usr/lib/redbor
 install -D -m 0755 resources/bin/rb_consumer.sh %{buildroot}/usr/lib/redborder/bin/rb_consumer.sh
 install -D -m 0755 resources/bin/rb_producer.sh %{buildroot}/usr/lib/redborder/bin/rb_producer.sh
 install -D -m 0644 resources/systemd/kafka.service %{buildroot}/usr/lib/systemd/system/kafka.service
+install -D -m 0755 resources/bin/rb_get_partitions.sh %{buildroot}/usr/lib/redborder/bin/rb_get_partitions.sh
 cp resources/scripts/*.rb %{buildroot}/usr/lib/redborder/scripts
 chmod 0755 %{buildroot}/usr/lib/redborder/scripts/*
 
@@ -41,6 +42,7 @@ chmod 0755 %{buildroot}/usr/lib/redborder/scripts/*
 /usr/lib/redborder/bin/rb_delete_topics.sh
 /usr/lib/redborder/bin/rb_consumer.sh
 /usr/lib/redborder/bin/rb_producer.sh
+/usr/lib/redborder/bin/rb_get_partitions.sh
 /usr/lib/redborder/scripts
 %defattr(0644,root,root)
 /usr/lib/systemd/system/kafka.service
@@ -51,8 +53,12 @@ chmod 0755 %{buildroot}/usr/lib/redborder/scripts/*
 %systemd_post kafka.service
 
 %changelog
+* Thu Jun 06 2024 Miguel Negron <manegron@redborder.com>
+- Add rb_get_partitions.sh
+
 * Fri Aug 26 2016 Carlos J Mateos <cjmateos@redborder.com> 1.0.0-1
 - Added stop script for systemd unit file
+
 * Tue Jul 28 2016 Enrique Jimenez <ejimenez@redborder.com> 1.0.0-1
 - Changed permissions for kafka script
 - Enabled systemd service in postinst

--- a/resources/bin/rb_get_partitions.sh
+++ b/resources/bin/rb_get_partitions.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#######################################################################    
+# Copyright (c) 2024 ENEO Tecnología S.L.
+# This file is part of redBorder.
+# redBorder is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# redBorder is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License License for more details.
+# You should have received a copy of the GNU Affero General Public License License
+# along with redBorder. If not, see <http://www.gnu.org/licenses/>.
+#######################################################################
+
+source $RBLIB/rb_manager_functions.sh
+ZK_HOST="zookeeper.service"
+
+TOPICS="$*"
+
+if [ "x$TOPICS" == "x" ]; then
+    for c in $(/usr/lib/redborder/scripts/rb_get_consumer_groups.rb 2>/dev/null); do 
+        [ "x$BOOTUP" != "xnone" ] && set_color cyan
+        echo "##############################################" 
+        echo -n "   Consumer Group: "
+        [ "x$BOOTUP" != "xnone" ] && set_color green
+        echo "$c"
+        [ "x$BOOTUP" != "xnone" ] && set_color cyan
+        echo "##############################################" 
+        [ "x$BOOTUP" != "xnone" ] && set_color norm
+         /usr/bin/kafka-run-class kafka.tools.ConsumerOffsetChecker --zookeeper $ZK_HOST --group $c | sed 's/^Group[ \t]*//' | sed "s/^$c[ \t]*//"
+        echo
+    done
+else
+    for n in $TOPICS; do
+        /usr/bin/kafka-run-class kafka.tools.ConsumerOffsetChecker --zookeeper $ZK_HOST --topic $n --group rb-group
+    done
+fi

--- a/resources/scripts/rb_get_consumer_groups.rb
+++ b/resources/scripts/rb_get_consumer_groups.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+########################################################################    
+## Copyright (c) 2024 ENEO Tecnología S.L.
+## This file is part of redBorder.
+## redBorder is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Affero General Public License License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+## redBorder is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Affero General Public License License for more details.
+## You should have received a copy of the GNU Affero General Public License License
+## along with redBorder. If not, see <http://www.gnu.org/licenses/>.
+########################################################################
+
+require 'zk'
+require 'yaml'
+require 'json'
+require 'getopt/std'
+
+zk_host='zookeeper.service:2181'
+
+begin 
+  zk = ZK.new(zk_host)
+  if zk.nil?
+    $stderr.puts "ERROR: Cannot connect with #{zk_host}!!"
+  elsif zk.exists?('/consumers')
+    zk.children('/consumers').sort.uniq.each do |x|
+      $stdout.puts x
+    end
+  end
+rescue => e
+  $stderr.puts "ERROR: Exception on #{zk_host}"
+  $stderr.puts "#{e}\n\t#{e.backtrace.join("\n\t")}" if @debug
+ensure
+  zk.close if zk && !zk.closed? 
+end


### PR DESCRIPTION
Redmine task: #17651

- Add these rb_get_partitions and rb_get_consumer_groups script to NG

Note: The goal of this task was not to refactor, but to make the scripts work with minimal changes and ensure the integrations were flawless.